### PR TITLE
ENH: Introduce class core::logger::Level

### DIFF
--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -11,7 +11,7 @@ int main(int argc, char *argv[])
 {
     core::Config config("./config/config.json");
     if (config.hasValue("loggerLevel"))
-        core::logger::setLevel(config.getValue("loggerLevel"));
+        core::logger::get().set_level(core::logger::Level(config.getValue("loggerLevel")));
 
     QCoreApplication::addLibraryPath(QStringLiteral("."));
     QApplication::setApplicationName(QStringLiteral("codeSource"));

--- a/src/core/logger/include/logger.h
+++ b/src/core/logger/include/logger.h
@@ -1,9 +1,10 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
-#include <string>
-
 #include <spdlog/logger.h>
+
+#include <ostream>
+#include <string>
 
 #define SPDLOG_BASE(logger, level, ...) (logger).log(::spdlog::source_loc{__FILE__, __LINE__, __func__}, level, __VA_ARGS__)
 #define TRACELOG(...) SPDLOG_BASE(::core::logger::get(), ::spdlog::level::trace, __VA_ARGS__)
@@ -17,9 +18,61 @@ namespace core
 {
     namespace logger
     {
+        class Level
+        {
+            using level_enum = spdlog::level::level_enum;
+
+        public:
+            Level(level_enum level = spdlog::level::trace);
+            Level(const std::string &level);
+
+            operator level_enum() const noexcept
+            {
+                return levelEnum;
+            }
+            operator const std::string &() const noexcept
+            {
+                return *levelStr;
+            }
+
+            friend bool operator ==(Level a, Level b) noexcept
+            {
+                return a.levelEnum == b.levelEnum;
+            }
+            friend bool operator !=(Level a, Level b) noexcept
+            {
+                return !(a == b);
+            }
+            friend std::ostream &operator <<(std::ostream &os, Level level)
+            {
+                return os << static_cast<const std::string &>(level);
+            }
+
+            static const Level trace;
+            static const Level debug;
+            static const Level info;
+            static const Level warn;
+            static const Level error;
+            static const Level critical;
+
+        private:
+            Level(level_enum levelEnum, const std::string &levelStr) noexcept
+                : levelEnum(levelEnum)
+                , levelStr(&levelStr)
+                {}
+
+            level_enum levelEnum;
+            const std::string *levelStr;
+
+            static const std::string traceStr;
+            static const std::string debugStr;
+            static const std::string infoStr;
+            static const std::string warnStr;
+            static const std::string errorStr;
+            static const std::string criticalStr;
+        };
 
         spdlog::logger &get();
-        void setLevel(const std::string &level);
 
     } // namespace logger
 } // namespace core

--- a/src/core/logger/src/logger.cpp
+++ b/src/core/logger/src/logger.cpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <stdexcept>
 #include <unordered_map>
 
 #include "spdlog/spdlog.h"
@@ -33,27 +34,56 @@ namespace core
             }
         } // unnamed namespace
 
+        Level::Level(level_enum level)
+        {
+            operator =(
+                level == spdlog::level::trace ? trace :
+                level == spdlog::level::debug ? debug :
+                level == spdlog::level::info ? info :
+                level == spdlog::level::warn ? warn :
+                level == spdlog::level::err ? error :
+                level == spdlog::level::critical ? critical :
+                throw std::invalid_argument(
+                    std::string("unrecognized spdlog::level::level_enum ") +
+                    std::to_string(level))
+            );
+        }
+
+        Level::Level(const std::string &level)
+        {
+            auto c = level.size() ? level[0] : '\0';
+            operator =(
+                c == 't' ? trace :
+                c == 'd' ? debug :
+                c == 'i' ? info :
+                c == 'w' ? warn :
+                c == 'e' ? error :
+                c == 'c' ? critical :
+                throw std::invalid_argument(
+                    std::string("unrecognized core::logger::Level string '") +
+                    level +
+                    '\'')
+            );
+        }
+
+        const std::string Level::traceStr("trace");
+        const std::string Level::debugStr("debug");
+        const std::string Level::infoStr("info");
+        const std::string Level::warnStr("warn");
+        const std::string Level::errorStr("error");
+        const std::string Level::criticalStr("critical");
+
+        const Level Level::trace(spdlog::level::trace, traceStr);
+        const Level Level::debug(spdlog::level::debug, debugStr);
+        const Level Level::info(spdlog::level::info, infoStr);
+        const Level Level::warn(spdlog::level::warn, warnStr);
+        const Level Level::error(spdlog::level::err, errorStr);
+        const Level Level::critical(spdlog::level::critical, criticalStr);
+
         spdlog::logger &get()
         {
             static std::shared_ptr<spdlog::logger> ptr = construct();
             return *ptr;
-        }
-
-        void setLevel(const std::string &level)
-        {
-            static const std::unordered_map<std::string, spdlog::level::level_enum> map = {
-                {"trace", spdlog::level::trace},
-                {"debug", spdlog::level::debug},
-                {"info", spdlog::level::info},
-                {"warn", spdlog::level::warn},
-                {"error", spdlog::level::err},
-                {"critical", spdlog::level::critical}};
-            auto it = map.find(level);
-            if (it != map.end())
-            {
-                get().set_level(it->second);
-                INFOLOG("change logger level to {}", level);
-            }
         }
 
     } // namespace logger


### PR DESCRIPTION
One solution to #8. `core::logger::Level` is a full-featured level class that bridges `spdlog::level::level_enum` and level string. May be a little bit overkill/heavy though. Maybe you could think of something lighter.